### PR TITLE
FEATURE: Make sort direction of the media browser configurable

### DIFF
--- a/TYPO3.Media/Classes/TYPO3/Media/Domain/Session/BrowserState.php
+++ b/TYPO3.Media/Classes/TYPO3/Media/Domain/Session/BrowserState.php
@@ -27,7 +27,7 @@ class BrowserState
         'activeTag' => null,
         'view' => 'Thumbnail',
         'sortBy' => 'Modified',
-        'sortDirection' => 'ASC',
+        'sortDirection' => 'DESC',
         'filter' => 'All'
     );
 


### PR DESCRIPTION
Changed sortDirection of the media browser back to DESC, so we see the most current media files in the media browser on the top.

This is a possible fix for Issue: https://github.com/neos/neos-development-collection/issues/1230 without the possibility for configuration.